### PR TITLE
TW-95680 Support new syntax of dotCover console 2025.2

### DIFF
--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/ArgumentsService.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/ArgumentsService.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer.agent
 
 interface ArgumentsService {

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/ArgumentsServiceImpl.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/ArgumentsServiceImpl.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer.agent
 
 import jetbrains.buildServer.util.StringUtil

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/CommandLine.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/CommandLine.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer.agent
 
 import jetbrains.buildServer.agent.runner.StdOutText

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/Path.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/Path.kt
@@ -1,9 +1,10 @@
-
-
 package jetbrains.buildServer.agent
 
 import java.io.File
 
+/**
+ * TODO: to someone who knows codebase better: please deprecate in favor of [java.nio.file.Path] or add a javadoc explaining the purpose of this class
+ */
 data class Path(val path: String) {
     override fun toString(): String = path
 }

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/Path.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/Path.kt
@@ -2,9 +2,6 @@ package jetbrains.buildServer.agent
 
 import java.io.File
 
-/**
- * TODO: to someone who knows codebase better: please deprecate in favor of [java.nio.file.Path] or add a javadoc explaining the purpose of this class
- */
 data class Path(val path: String) {
     override fun toString(): String = path
 }

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/Version.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/Version.kt
@@ -174,5 +174,6 @@ class Version private constructor(
         val MinDotnetVersionForTestSuppressor: Version = Version(6)
         val MinDotNetFrameworkVersionForDotCover = Version(4, 7, 2)
         val MinDotNetSdkVersionForDotCover = Version(3, 1)
+        val MinDotNetSdkVersionForDotCoverV3 = Version(8, 0)
     }
 }

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/runner/WorkflowContext.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/runner/WorkflowContext.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer.agent.runner
 
 import jetbrains.buildServer.agent.*

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/runner/WorkflowSessionImpl.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/runner/WorkflowSessionImpl.kt
@@ -6,9 +6,9 @@ import jetbrains.buildServer.rx.Observer
 import jetbrains.buildServer.rx.subjectOf
 
 class WorkflowSessionImpl(
-        private val _workflowComposer: SimpleWorkflowComposer,
-        private val _commandExecutionFactory: CommandExecutionFactory,
-        private val _workflowSessionEventDispatcher: WorkflowSessionEventDispatcher
+    private val _workflowComposer: SimpleWorkflowComposer,
+    private val _commandExecutionFactory: CommandExecutionFactory,
+    private val _workflowSessionEventDispatcher: WorkflowSessionEventDispatcher
 ) : MultiCommandBuildSession, WorkflowContext {
 
     private val _commandLinesIterator = lazy { _workflowComposer.compose(this, Unit).commandLines.iterator() }

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/CoverageFilter.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/CoverageFilter.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer.dotcover
 
 data class CoverageFilter(
@@ -7,17 +5,17 @@ data class CoverageFilter(
         var defaultMask: String = Any,
         var moduleMask: String = Any,
         val classMask: String = Any,
-        val functionMask: String = Any) {
-
+        val functionMask: String = Any
+) {
     override fun toString(): String {
         return "$typeStr:$defaultMask;module=$moduleMask;class=$classMask;function=$functionMask"
     }
 
     private val typeStr: String
         get() = when (type) {
-            CoverageFilter.CoverageFilterType.Undefined -> UnspecifiedSymbol
-            CoverageFilter.CoverageFilterType.Include -> IncludeSymbol
-            CoverageFilter.CoverageFilterType.Exclude -> ExcludeSymbol
+            CoverageFilterType.Undefined -> UnspecifiedSymbol
+            CoverageFilterType.Include -> IncludeSymbol
+            CoverageFilterType.Exclude -> ExcludeSymbol
         }
 
     companion object {

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverEntryPointSelectorImpl.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverEntryPointSelectorImpl.kt
@@ -55,6 +55,7 @@ class DotCoverEntryPointSelectorImpl(
                         "installed to run the \"dotCover Cross-Platform\" tool"
                     ))
                 }
+                DotCoverToolType.CrossPlatformV3 -> Result.success(_tool.dotCoverDllFile)
                 DotCoverToolType.Unknown -> Result.failure(ToolCannotBeFoundException(
                     "dotCover has been run on Windows, however " +
                     "${_tool.dotCoverDllFile.name} or ${_tool.dotCoverExeFile.name} " +
@@ -73,6 +74,7 @@ class DotCoverEntryPointSelectorImpl(
                         "installed to run the \"dotCover Cross-Platform\" tool"
                     ))
                 }
+                DotCoverToolType.CrossPlatformV3 -> Result.success(_tool.dotCoverDllFile)
                 DotCoverToolType.WindowsOnly -> Result.failure(UnsatisfiedRequirementError(
                     "dotCover has been run on Linux or macOS agent, however it's using a tool designed for Windows"
                 ))
@@ -88,7 +90,7 @@ class DotCoverEntryPointSelectorImpl(
     private class UnsatisfiedRequirementError(message: String) : Error(message)
 
     private val crossPlatformToolRequirementsText get() =
-        _tool.getCrossPlatformVersionMinRequirement(_virtualContext.targetOSType).joinToString(" or ")
+        _tool.getCrossPlatformVersionMinRequirement(_virtualContext.targetOSType, _tool.type).joinToString(" or ")
 
     companion object {
         internal const val DOTCOVER_REQUIREMENTS_BUILD_PROBLEM = "dotCover_requirements_have_not_been_met"

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverEntryPointSelectorImpl.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverEntryPointSelectorImpl.kt
@@ -55,7 +55,13 @@ class DotCoverEntryPointSelectorImpl(
                         "installed to run the \"dotCover Cross-Platform\" tool"
                     ))
                 }
-                DotCoverToolType.CrossPlatformV3 -> Result.success(_tool.dotCoverDllFile)
+                DotCoverToolType.CrossPlatformV3 -> when {
+                    _virtualContext.isVirtual or _tool.canUseDotNetRuntime -> Result.success(_tool.dotCoverDllFile)
+                    else -> Result.failure(UnsatisfiedRequirementError(
+                        "Windows agents must have $crossPlatformToolRequirementsText " +
+                        "installed to run the \"dotCover Cross-Platform\" tool"
+                    ))
+                }
                 DotCoverToolType.Unknown -> Result.failure(ToolCannotBeFoundException(
                     "dotCover has been run on Windows, however " +
                     "${_tool.dotCoverDllFile.name} or ${_tool.dotCoverExeFile.name} " +
@@ -74,7 +80,13 @@ class DotCoverEntryPointSelectorImpl(
                         "installed to run the \"dotCover Cross-Platform\" tool"
                     ))
                 }
-                DotCoverToolType.CrossPlatformV3 -> Result.success(_tool.dotCoverDllFile)
+                DotCoverToolType.CrossPlatformV3 -> when {
+                    _virtualContext.isVirtual or _tool.canUseDotNetRuntime -> Result.success(_tool.dotCoverDllFile)
+                    else -> Result.failure(UnsatisfiedRequirementError(
+                        "Windows agents must have $crossPlatformToolRequirementsText " +
+                                "installed to run the \"dotCover Cross-Platform\" tool"
+                    ))
+                }
                 DotCoverToolType.WindowsOnly -> Result.failure(UnsatisfiedRequirementError(
                     "dotCover has been run on Linux or macOS agent, however it's using a tool designed for Windows"
                 ))

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverProject.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverProject.kt
@@ -3,27 +3,39 @@ package jetbrains.buildServer.dotcover
 import jetbrains.buildServer.agent.CommandLine
 import jetbrains.buildServer.agent.Path
 import jetbrains.buildServer.dotcover.command.DotCoverCommandType
-import java.io.File
 
 data class DotCoverProject(
-        val dotCoverCommandType: DotCoverCommandType,
-        val coverCommandData: CoverCommandData? = null,
-        val mergeCommandData: MergeCommandData? = null,
-        val reportCommandData: ReportCommandData? = null) {
+    val dotCoverCommandType: DotCoverCommandType,
+    val coverCommandData: CoverCommandData? = null,
+    val mergeCommandData: MergeCommandData? = null,
+    val reportCommandData: ReportCommandData? = null
+) {
+    data class CoverCommandData(
+        val commandLineToCover: CommandLine,
 
-        data class CoverCommandData(
-                val commandLineToCover: CommandLine,
-                val configFile: Path,
-                val snapshotFile: Path
-        )
+        /**
+         * File to hold part or all of the cli parameters.
+         * Depending on the dotCover version, the file may be either XML config or
+         * response file.
+         *
+         * @see DotCoverRunConfigFileSerializer
+         * @see DotCoverResponseFileSerializer
+         */
+        val commandLineParamsFile: Path,
 
-        data class MergeCommandData(
-                val sourceFiles: List<Path>,
-                val outputFile: Path
-        )
+        /**
+         * Path to the resulting coverage snapshot.
+         */
+        val snapshotFile: Path
+    )
 
-        data class ReportCommandData(
-                val sourceFile: Path,
-                val outputFile: Path
-        )
+    data class MergeCommandData(
+        val sourceFiles: List<Path>,
+        val outputFile: Path
+    )
+
+    data class ReportCommandData(
+        val sourceFile: Path,
+        val outputFile: Path
+    )
 }

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverProjectSerializer.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverProjectSerializer.kt
@@ -1,5 +1,0 @@
-package jetbrains.buildServer.dotcover
-
-import jetbrains.buildServer.Serializer
-
-interface DotCoverProjectSerializer : Serializer<DotCoverProject>

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverResponseFileSerializer.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverResponseFileSerializer.kt
@@ -1,0 +1,13 @@
+package jetbrains.buildServer.dotcover
+
+import jetbrains.buildServer.Serializer
+
+/**
+ * Interface for serializing a [DotCoverProject] into a response file for storing
+ * DotCover command line parameters in accordance with the
+ * [Command Line Reference](https://www.jetbrains.com/help/dotcover/2025.3/dotCover__Console_Runner_Commands.html).
+ *
+ * Note that the response file format is only supported for versions *2025.2 and newer*.
+ * To store command line parameters for versions 2025.1 and earlier, use [DotCoverRunConfigFileSerializer].
+ */
+interface DotCoverResponseFileSerializer : Serializer<DotCoverProject>

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverResponseFileSerializerImpl.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverResponseFileSerializerImpl.kt
@@ -1,0 +1,120 @@
+package jetbrains.buildServer.dotcover
+
+import jetbrains.buildServer.agent.ArgumentsService
+import jetbrains.buildServer.agent.runner.LoggerService
+import jetbrains.buildServer.dotcover.command.DotCoverCommandType
+import jetbrains.buildServer.dotnet.commands.msbuild.MSBuildParameterNormalizer.normalizeAndQuoteValue
+import java.io.OutputStream
+import java.io.PrintWriter
+
+class DotCoverResponseFileSerializerImpl(
+    private val _argumentsService: ArgumentsService,
+    private val _coverageFilterProvider: CoverageFilterProvider,
+    private val _loggerService: LoggerService
+) : DotCoverResponseFileSerializer {
+    override fun serialize(obj: DotCoverProject, outputStream: OutputStream) {
+        val writer = PrintWriter(outputStream)
+        when (obj.dotCoverCommandType) {
+            DotCoverCommandType.Cover -> serializeForCover(requireNotNull(obj.coverCommandData), writer)
+            DotCoverCommandType.Merge -> serializeForMerge(requireNotNull(obj.mergeCommandData), writer)
+            DotCoverCommandType.Report -> serializeForReport(requireNotNull(obj.reportCommandData), writer)
+        }
+        writer.flush()
+    }
+
+    private fun serializeForCover(commandData: DotCoverProject.CoverCommandData, writer: PrintWriter) {
+        val workingDirectory = commandData.commandLineToCover.workingDirectory
+        with (writer) {
+            println("--target-executable")
+            println(safe(commandData.commandLineToCover.executableFile.path))
+            println("--target-working-directory")
+            println(safe(workingDirectory.path))
+            println("--snapshot-output")
+            println(safe(commandData.snapshotFile.path))
+
+            // --exclude-assemblies
+            val excludeAssemblies = mutableListOf<String>()
+            for (filter in _coverageFilterProvider.filters) {
+                when (filter.type) {
+                    CoverageFilter.CoverageFilterType.Include -> {
+                        if (filter.moduleMask != CoverageFilter.Any
+                            || filter.classMask != CoverageFilter.Any
+                            || filter.functionMask != CoverageFilter.Any) {
+                            _loggerService.writeWarning(
+                                "Coverage filter '$filter' cannot be applied: " +
+                                        "include filters are not supported in dotCover 2025.2+"
+                            )
+                        }
+                    }
+
+                    CoverageFilter.CoverageFilterType.Exclude -> {
+                        val hasClassOrFunction = filter.classMask != CoverageFilter.Any
+                                || filter.functionMask != CoverageFilter.Any
+
+                        if (filter.moduleMask == CoverageFilter.Any && hasClassOrFunction) {
+                            _loggerService.writeWarning(
+                                "Coverage filter '$filter' cannot be applied: " +
+                                        "class/function-level filters are not supported in dotCover 2025.2+"
+                            )
+                            continue
+                        }
+
+                        if (hasClassOrFunction) {
+                            _loggerService.writeWarning(
+                                "Coverage filter '$filter' is partially applied: " +
+                                        "only the assembly mask '${filter.moduleMask}' will be used; " +
+                                        "class/function-level filters are not supported in dotCover 2025.2+"
+                            )
+                        }
+
+                        excludeAssemblies.add(filter.moduleMask)
+                    }
+
+                    else -> { }
+                }
+            }
+
+            if (excludeAssemblies.isNotEmpty()) {
+                println("--exclude-assemblies")
+                println(excludeAssemblies.joinToString(","))
+            }
+
+            // --exclude-attributes
+            val excludeAttributes = _coverageFilterProvider.attributeFilters
+                .map { it.classMask }
+                .filter { it != CoverageFilter.Any }
+                .toList()
+            if (excludeAttributes.isNotEmpty()) {
+                println("--exclude-attributes")
+                println(excludeAttributes.joinToString(","))
+            }
+
+            if (commandData.commandLineToCover.arguments.isNotEmpty()) {
+                println("--") // alias for --target-arguments
+                println(_argumentsService.combine(commandData.commandLineToCover.arguments.map { it.value }.asSequence()))
+            }
+        }
+    }
+
+    private fun serializeForMerge(commandData: DotCoverProject.MergeCommandData, writer: PrintWriter) {
+        with(writer) {
+            println("--snapshot-source")
+            println(safe(commandData.sourceFiles.map { it.path }.joinToString(",")))
+            println("--snapshot-output")
+            println(safe(commandData.outputFile.path))
+        }
+    }
+
+    private fun serializeForReport(commandData: DotCoverProject.ReportCommandData, writer: PrintWriter) {
+        with(writer) {
+            println("--snapshot-source")
+            println(safe(commandData.sourceFile.path))
+            println("--xml-report-output")
+            println(safe(commandData.outputFile.path))
+        }
+    }
+
+    private fun safe(value: String): String {
+        return normalizeAndQuoteValue(value, fullEscaping = false, quoteOnOneTrailingBackslash = false)
+    }
+}

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverRunConfigFileSerializer.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverRunConfigFileSerializer.kt
@@ -1,0 +1,13 @@
+package jetbrains.buildServer.dotcover
+
+import jetbrains.buildServer.Serializer
+
+/**
+ * Interface for serializing a [DotCoverProject] into an XML configuration for storing
+ * DotCover command line parameters in accordance with the
+ * [Command Line Reference](https://www.jetbrains.com/help/dotcover/2025.1/dotCover__Console_Runner_Commands.html).
+ *
+ * Note that the XML configuration produced with this serializer is only supported for versions *2025.1 and earlier*.
+ * To store command line parameters for versions 2025.2 and newer, use [DotCoverResponseFileSerializer].
+ */
+interface DotCoverRunConfigFileSerializer : Serializer<DotCoverProject>

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverRunConfigFileSerializerImpl.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/DotCoverRunConfigFileSerializerImpl.kt
@@ -8,11 +8,11 @@ import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.io.OutputStream
 
-class DotCoverProjectSerializerImpl(
+class DotCoverRunConfigFileSerializerImpl(
         private val _xmlDocumentService: XmlDocumentService,
         private val _argumentsService: ArgumentsService,
         private val _coverageFilterProvider: CoverageFilterProvider)
-    : DotCoverProjectSerializer {
+    : DotCoverRunConfigFileSerializer {
 
     @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
     override fun serialize(project: DotCoverProject, outputStream: OutputStream) {

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/command/DotCoverCommandLineBuilder.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/command/DotCoverCommandLineBuilder.kt
@@ -11,7 +11,7 @@ interface DotCoverCommandLineBuilder {
     fun buildCommand(
         executableFile: Path,
         environmentVariables: List<CommandLineEnvironmentVariable>,
-        configFilePath: String,
+        commandLineParamsFilePath: String,
         baseCommandLine: CommandLine? = null
     ): CommandLine
 }

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/command/DotCoverCommandLineBuilderBase.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/command/DotCoverCommandLineBuilderBase.kt
@@ -5,6 +5,8 @@ import jetbrains.buildServer.agent.runner.ParameterType
 import jetbrains.buildServer.agent.runner.ParametersService
 import jetbrains.buildServer.agent.runner.PathType
 import jetbrains.buildServer.agent.runner.PathsService
+import jetbrains.buildServer.dotcover.tool.DotCoverAgentTool
+import jetbrains.buildServer.dotcover.tool.DotCoverToolType
 import jetbrains.buildServer.dotnet.CoverageConstants
 import jetbrains.buildServer.util.OSType
 
@@ -12,15 +14,37 @@ abstract class DotCoverCommandLineBuilderBase(
     private val _pathsService: PathsService,
     private val _virtualContext: VirtualContext,
     private val _parametersService: ParametersService,
-    private val _fileSystemService: FileSystemService
+    private val _fileSystemService: FileSystemService,
+    private val _dotCoverAgentTool : DotCoverAgentTool,
 ) : DotCoverCommandLineBuilder {
 
     protected val workingDirectory get() =
         Path(_pathsService.getPath(PathType.WorkingDirectory).canonicalPath)
 
-    protected val argumentPrefix get() = when(_virtualContext.targetOSType) {
-        OSType.WINDOWS -> "/"
-        else -> "--"
+    protected val argumentPrefix get(): String {
+        if (_dotCoverAgentTool.type == DotCoverToolType.CrossPlatformV3) {
+            return "--" // For DotCover 2025.2+, it's always "--" no matter the OS
+        }
+        return when (_virtualContext.targetOSType) {
+            OSType.WINDOWS -> "/"
+            else -> "--"
+        }
+    }
+
+    /**
+     * Provides a prefix for a filename that contains command line parameters.
+     * The prefix is only needed for the new versions of DotCover (2025.2 and newer).
+     *
+     * Example of using the prefix '@':
+     * ```bash
+     * dotCover cover @args.txt
+     * ```
+     *
+     * @see <a href="https://www.jetbrains.com/help/dotcover/2025.3/dotCover__Console_Runner_Commands.html">DotCover command line reference</a>
+     */
+    protected val commandLineParametersFilePrefix get() = when(_dotCoverAgentTool.type) {
+        DotCoverToolType.CrossPlatformV3 -> "@"
+        else -> ""
     }
 
     protected val logFileName get() =

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/command/DotCoverCoverCommandLineBuilder.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/command/DotCoverCoverCommandLineBuilder.kt
@@ -13,6 +13,8 @@ import jetbrains.buildServer.agent.runner.BuildStepContext
 import jetbrains.buildServer.agent.runner.ParameterType
 import jetbrains.buildServer.agent.runner.ParametersService
 import jetbrains.buildServer.agent.runner.PathsService
+import jetbrains.buildServer.dotcover.tool.DotCoverAgentTool
+import jetbrains.buildServer.dotcover.tool.DotCoverToolType
 import jetbrains.buildServer.dotnet.CoverageConstants
 import jetbrains.buildServer.dotnet.MonoConstants
 import jetbrains.buildServer.mono.MonoToolProvider
@@ -20,19 +22,20 @@ import jetbrains.buildServer.mono.MonoToolProvider
 class DotCoverCoverCommandLineBuilder(
     pathsService: PathsService,
     virtualContext: VirtualContext,
+    private val _dotCoverAgentTool: DotCoverAgentTool,
     private val _parametersService: ParametersService,
-    fileSystemService: FileSystemService,
+    private val _fileSystemService: FileSystemService,
     private val _argumentsService: ArgumentsService,
     private val _buildStepContext: BuildStepContext,
-    private val _monoToolProvider: MonoToolProvider
-) : DotCoverCommandLineBuilderBase(pathsService, virtualContext, _parametersService, fileSystemService) {
+    private val _monoToolProvider: MonoToolProvider,
+) : DotCoverCommandLineBuilderBase(pathsService, virtualContext, _parametersService, _fileSystemService, _dotCoverAgentTool) {
 
     override val type: DotCoverCommandType get() = DotCoverCommandType.Cover
 
     override fun buildCommand(
         executableFile: Path,
         environmentVariables: List<CommandLineEnvironmentVariable>,
-        configFilePath: String,
+        commandLineParamsFilePath: String,
         baseCommandLine: CommandLine?
     ): CommandLine {
         return CommandLine(
@@ -40,13 +43,13 @@ class DotCoverCoverCommandLineBuilder(
             target = TargetType.CodeCoverageProfiler,
             executableFile = executableFile,
             workingDirectory = baseCommandLine.workingDirectory,
-            arguments = createArguments(configFilePath, baseCommandLine.executableFile).toList(),
+            arguments = createArguments(commandLineParamsFilePath, baseCommandLine.executableFile).toList(),
             environmentVariables = environmentVariables,
             title = baseCommandLine.title
         )
     }
 
-    private fun createArguments(configFilePath: String, executableFile: Path): Sequence<CommandLineArgument> = sequence {
+    private fun createArguments(commandLineParamsFilePath: String, executableFile: Path): Sequence<CommandLineArgument> = sequence {
         val monoExecutable = runCatching { _monoToolProvider.getPath(
             MonoConstants.RUNNER_TYPE,
             _buildStepContext.runnerContext.build,
@@ -57,11 +60,23 @@ class DotCoverCoverCommandLineBuilder(
         } else {
             yield(CommandLineArgument("cover", CommandLineArgumentType.Mandatory))
         }
-        yield(CommandLineArgument(configFilePath, CommandLineArgumentType.Target))
-        yield(CommandLineArgument("${argumentPrefix}ReturnTargetExitCode"))
-        yield(CommandLineArgument("${argumentPrefix}AnalyzeTargetArguments=false"))
+        yield(CommandLineArgument(commandLineParametersFilePrefix + commandLineParamsFilePath, CommandLineArgumentType.Target))
+        if (_dotCoverAgentTool.type != DotCoverToolType.CrossPlatformV3) {
+            // Not supported in DotCover 2025.2+
+            yield(CommandLineArgument("${argumentPrefix}ReturnTargetExitCode"))
+            yield(CommandLineArgument("${argumentPrefix}AnalyzeTargetArguments=false"))
 
-        logFileName?.let { yield(CommandLineArgument("${argumentPrefix}LogFile=${it}", CommandLineArgumentType.Infrastructural)) }
+            // Syntax of 2025.1 or earlier
+            logFileName?.let {
+                yield(CommandLineArgument("${argumentPrefix}LogFile=${it}", CommandLineArgumentType.Infrastructural))
+            }
+        } else {
+            // Syntax of 2025.2+
+            logFileName?.let { logFileName ->
+                yield(CommandLineArgument("${argumentPrefix}log-file", CommandLineArgumentType.Infrastructural))
+                yield(CommandLineArgument(logFileName, CommandLineArgumentType.Infrastructural))
+            }
+        }
 
         _parametersService.tryGetParameter(ParameterType.Runner, CoverageConstants.PARAM_DOTCOVER_ARGUMENTS)?.let {
             _argumentsService.split(it).forEach {

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/tool/DotCoverAgentTool.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/tool/DotCoverAgentTool.kt
@@ -8,6 +8,7 @@ import jetbrains.buildServer.dotnet.CoverageConstants
 import jetbrains.buildServer.dotnet.DotnetConstants
 import jetbrains.buildServer.dotnet.coverage.serviceMessage.DotnetCoverageParametersHolder
 import jetbrains.buildServer.util.OSType
+import org.jdom.input.SAXBuilder
 import java.io.File
 
 class DotCoverAgentTool(
@@ -15,30 +16,43 @@ class DotCoverAgentTool(
     private val _fileSystemService: FileSystemService,
     private val _coverageParametersHolder: DotnetCoverageParametersHolder,
 ) {
-    val dotCoverExeFile get() = EntryPointType.WindowsExecutable.getEntryPointFile(dotCoverHomePath)
-
-    val dotCoverDllFile get() = EntryPointType.UsingAgentDotnetRuntime.getEntryPointFile(dotCoverHomePath)
-
-    val dotCoverShFile get() = EntryPointType.UsingBundledDotnetRuntime.getEntryPointFile(dotCoverHomePath)
-
     val dotCoverHomePath
         get() = _parametersService.tryGetParameter(ParameterType.Runner, CoverageConstants.PARAM_DOTCOVER_HOME)
             ?.takeUnless { it.isBlank() }
             ?: tryGetDotCoverHomePathFromParameterHolder()
             ?: ""
 
+    val dotCoverExeFile get() = EntryPointType.WindowsExecutable.getEntryPointFile(dotCoverHomePath)
+
+    val dotCoverDllFile get() = EntryPointType.UsingAgentDotnetRuntime.getEntryPointFile(dotCoverHomePath)
+
+    val dotCoverShFile get() = EntryPointType.UsingBundledDotnetRuntime.getEntryPointFile(dotCoverHomePath)
+
+    val pluginDescriptorFile get() = File(dotCoverHomePath).resolve("teamcity-plugin.xml")
+
+    /**
+     * Retrieves the DotCover API version from the plugin descriptor.
+     *
+     * The value is extracted by querying the plugin descriptor for the
+     * `dotCoverApiVersion` parameter, converting the result to an integer if possible.
+     * If the parameter value is absent or non-numeric, null is returned.
+     */
+    val apiVersion get(): Int? = readPluginDescriptorParameter("dotCoverApiVersion")?.toIntOrNull()
+
     val type get() = when {
         // cross-platform version using bundled runtime
         _fileSystemService.isExists(dotCoverShFile) ->
             DotCoverToolType.DeprecatedCrossPlatform
 
-        // Windows-only version using agent requirements mechanism – no build-time requirements checking needed
+        // Windows-only version using an agent requirements mechanism – no build-time requirements checking needed
         _fileSystemService.isExists(dotCoverExeFile) && !_fileSystemService.isExists(dotCoverDllFile) ->
             DotCoverToolType.WindowsOnly
 
         // cross-platform version using agent runtime
         _fileSystemService.isExists(dotCoverDllFile) && !_fileSystemService.isExists(dotCoverShFile) ->
             DotCoverToolType.CrossPlatform
+
+        apiVersion == 3 -> DotCoverToolType.CrossPlatformV3
 
         else -> DotCoverToolType.Unknown
     }
@@ -49,18 +63,24 @@ class DotCoverAgentTool(
     val canUseDotNetFrameworkRuntime get() =
         satisfiedRequirements.contains(MinRequirement.DotnetFramework472) && _fileSystemService.isExists(dotCoverExeFile)
 
-    fun getCrossPlatformVersionMinRequirement(os: OSType) = when (os) {
-        OSType.WINDOWS -> sequenceOf(
-            MinRequirement.DotnetCore31.requirementName,
-            MinRequirement.DotnetFramework472.requirementName
-        )
+    fun getCrossPlatformVersionMinRequirement(os: OSType, toolType: DotCoverToolType): Sequence<String> {
+        if (toolType == DotCoverToolType.CrossPlatformV3) {
+            return sequenceOf(MinRequirement.DotnetCore8.requirementName)
+        }
 
-        else -> sequenceOf(MinRequirement.DotnetCore31.requirementName)
+        return when (os) {
+            OSType.WINDOWS -> sequenceOf(
+                    MinRequirement.DotnetCore31.requirementName,
+                    MinRequirement.DotnetFramework472.requirementName,
+                )
+
+            else -> sequenceOf(MinRequirement.DotnetCore31.requirementName)
+        }
     }
 
     private val satisfiedRequirements : List<MinRequirement> get() {
         val buildParametersNames = _parametersService.getParameterNames(ParameterType.Configuration)
-        return MinRequirement.values().filter { req -> buildParametersNames.any { req.isSatisfiedBy(it) } }
+        return MinRequirement.entries.filter { req -> buildParametersNames.any { req.isSatisfiedBy(it) } }
     }
 
     // When the dotCover path is set via the "##teamcity[dotNetCoverageDotnetRunner dotcover_home='/path/to/dotcover']"
@@ -119,6 +139,13 @@ class DotCoverAgentTool(
             Version.MinDotNetSdkVersionForDotCover,
             DotnetConstants.CONFIG_SUFFIX_PATH,
             ".NET Core 3.1+"
+        ),
+
+        DotnetCore8(
+            DotnetConstants.CONFIG_PREFIX_CORE_RUNTIME,
+            Version.MinDotNetSdkVersionForDotCoverV3,
+            DotnetConstants.CONFIG_SUFFIX_PATH,
+            ".NET Core 8+"
         );
 
         private val regexPattern = "^$prefix(.+)$suffix$".toRegex()
@@ -131,6 +158,18 @@ class DotCoverAgentTool(
                     else -> false
                 }
             }
+    }
+
+    private fun readPluginDescriptorParameter(parameterName: String): String? {
+        val inputStream = pluginDescriptorFile.inputStream()
+        val doc = SAXBuilder().build(inputStream)
+        val root = doc.rootElement
+        val params = root.getChild("parameters") ?: return null
+        return params.getChildren("parameter")
+            .asSequence()
+            .filterIsInstance<org.jdom.Element>()
+            .firstOrNull { it.getAttribute("name")?.value == parameterName }
+            ?.textTrim
     }
 }
 

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/tool/DotCoverAgentTool.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/tool/DotCoverAgentTool.kt
@@ -54,8 +54,6 @@ class DotCoverAgentTool(
         _fileSystemService.isExists(dotCoverDllFile) && !_fileSystemService.isExists(dotCoverShFile) ->
             DotCoverToolType.CrossPlatform
 
-        apiVersion == 3 -> DotCoverToolType.CrossPlatformV3
-
         else -> DotCoverToolType.Unknown
     }
 
@@ -163,8 +161,12 @@ class DotCoverAgentTool(
     }
 
     private fun readPluginDescriptorParameter(parameterName: String): String? {
-        val inputStream = pluginDescriptorFile.inputStream()
-        val doc = SAXBuilder().build(inputStream)
+        if (!_fileSystemService.isExists(pluginDescriptorFile)) {
+            return null
+        }
+        val doc = pluginDescriptorFile.inputStream().use { stream ->
+            SAXBuilder().build(stream)
+        }
         val root = doc.rootElement
         val params = root.getChild("parameters") ?: return null
         return params.getChildren("parameter")

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/tool/DotCoverAgentTool.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/tool/DotCoverAgentTool.kt
@@ -40,6 +40,8 @@ class DotCoverAgentTool(
     val apiVersion get(): Int? = readPluginDescriptorParameter("dotCoverApiVersion")?.toIntOrNull()
 
     val type get() = when {
+        apiVersion == 3 -> DotCoverToolType.CrossPlatformV3
+
         // cross-platform version using bundled runtime
         _fileSystemService.isExists(dotCoverShFile) ->
             DotCoverToolType.DeprecatedCrossPlatform
@@ -51,8 +53,6 @@ class DotCoverAgentTool(
         // cross-platform version using agent runtime
         _fileSystemService.isExists(dotCoverDllFile) && !_fileSystemService.isExists(dotCoverShFile) ->
             DotCoverToolType.CrossPlatform
-
-        apiVersion == 3 -> DotCoverToolType.CrossPlatformV3
 
         else -> DotCoverToolType.Unknown
     }

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/tool/DotCoverToolType.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotcover/tool/DotCoverToolType.kt
@@ -4,8 +4,11 @@ enum class DotCoverToolType {
     // JetBrains.dotCover.CommandLine NuGet package before 2023.3
     WindowsOnly,
 
-    // JetBrains.dotCover.CommandLine NuGet package since 2023.3
+    // JetBrains.dotCover.CommandLine NuGet package since 2023.3 and before 2025.2
     CrossPlatform,
+
+    // JetBrains.dotCover.CommandLine NuGet package since 2025.2
+    CrossPlatformV3,
 
     // JetBrains.dotCover.DotNetCli NuGet package
     DeprecatedCrossPlatform,

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotnet/DotnetCommandContext.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotnet/DotnetCommandContext.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer.dotnet
 
 import jetbrains.buildServer.agent.ToolPath

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotnet/commands/responseFile/ResponseFileArgumentsProvider.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotnet/commands/responseFile/ResponseFileArgumentsProvider.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer.dotnet.commands.responseFile
 
 import jetbrains.buildServer.agent.CommandLineArgument

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotnet/commands/responseFile/ResponseFileFactory.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotnet/commands/responseFile/ResponseFileFactory.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer.dotnet.commands.responseFile
 
 import jetbrains.buildServer.agent.CommandLineArgument

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/script/CommandLineFactoryImpl.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/script/CommandLineFactoryImpl.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer.script
 
 import jetbrains.buildServer.agent.*

--- a/plugin-dotnet-agent/src/main/resources/META-INF/build-agent-plugin-dotnet.xml
+++ b/plugin-dotnet-agent/src/main/resources/META-INF/build-agent-plugin-dotnet.xml
@@ -597,7 +597,8 @@
   <bean class="jetbrains.buildServer.dotcover.DotCoverWorkflowComposer" id="dotCoverWorkflowComposer"/>
   <bean class="jetbrains.buildServer.dotcover.DotCoverReportingWorkflowComposer" id="dotCoverReportingWorkflowComposer"/>
   <bean class="jetbrains.buildServer.dotcover.DotCoverProfiledProcessWorkflowComposer"/>
-  <bean class="jetbrains.buildServer.dotcover.DotCoverProjectSerializerImpl"/>
+  <bean class="jetbrains.buildServer.dotcover.DotCoverRunConfigFileSerializerImpl"/>
+  <bean class="jetbrains.buildServer.dotcover.DotCoverResponseFileSerializerImpl"/>
   <bean class="jetbrains.buildServer.dotcover.DotCoverFilterConverterImpl"/>
   <bean class="jetbrains.buildServer.dotcover.DotCoverFilterProvider"/>
   <bean class="jetbrains.buildServer.dotcover.DotCoverEnvironmentVariables"/>

--- a/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/dotcover/DotCoverAgentToolTest.kt
+++ b/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/dotcover/DotCoverAgentToolTest.kt
@@ -185,7 +185,7 @@ class DotCoverAgentToolTest {
     @Test
     fun `should get correct cross-platform version min requirement for windows`() {
         // act
-        val result = _tool.getCrossPlatformVersionMinRequirement(OSType.WINDOWS).toList()
+        val result = _tool.getCrossPlatformVersionMinRequirement(OSType.WINDOWS, DotCoverToolType.CrossPlatform).toList()
 
         // assert
         Assert.assertEquals(result.count(), 2)
@@ -195,7 +195,7 @@ class DotCoverAgentToolTest {
     @Test
     fun `should get correct cross-platform version min requirement for non-windows`() {
         // act
-        val result = _tool.getCrossPlatformVersionMinRequirement(OSType.UNIX).toList()
+        val result = _tool.getCrossPlatformVersionMinRequirement(OSType.UNIX, DotCoverToolType.CrossPlatform).toList()
 
         // assert
         Assert.assertEquals(result.count(), 1)

--- a/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/dotcover/DotCoverResponseFileSerializerTest.kt
+++ b/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/dotcover/DotCoverResponseFileSerializerTest.kt
@@ -1,0 +1,206 @@
+package jetbrains.buildServer.dotnet.test.dotcover
+
+import jetbrains.buildServer.Serializer
+import jetbrains.buildServer.agent.ArgumentsService
+import jetbrains.buildServer.agent.CommandLine
+import jetbrains.buildServer.agent.CommandLineArgument
+import jetbrains.buildServer.agent.Path
+import jetbrains.buildServer.agent.TargetType
+import jetbrains.buildServer.agent.runner.LoggerService
+import jetbrains.buildServer.dotcover.CoverageFilter
+import jetbrains.buildServer.dotcover.CoverageFilterProvider
+import jetbrains.buildServer.dotcover.DotCoverProject
+import jetbrains.buildServer.dotcover.DotCoverProject.CoverCommandData
+import jetbrains.buildServer.dotcover.DotCoverResponseFileSerializerImpl
+import jetbrains.buildServer.dotcover.command.DotCoverCommandType
+import jetbrains.buildServer.dotnet.test.agent.ArgumentsServiceStub
+import jetbrains.buildServer.dotnet.test.rx.assertEquals
+import org.jmock.Expectations
+import org.jmock.Mockery
+import org.testng.Assert
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+class DotCoverResponseFileSerializerTest {
+    private val _argumentsService: ArgumentsService = ArgumentsServiceStub()
+    private lateinit var _ctx: Mockery
+    private lateinit var _coverageFilterProvider: CoverageFilterProvider
+    private lateinit var _loggerService: LoggerService
+
+    @BeforeMethod
+    fun setUp() {
+        _ctx = Mockery()
+        _loggerService = _ctx.mock<LoggerService>(LoggerService::class.java)
+        _coverageFilterProvider = _ctx.mock<CoverageFilterProvider>(CoverageFilterProvider::class.java)
+    }
+
+    @Test
+    fun `should generate cover command content`() {
+        // Arrange
+        val outputStream = ByteArrayOutputStream()
+        val tempDir = File("temp")
+        val workingDirectory = Path(File("wd").path)
+        val tool = Path(File("wd", "tool").path)
+        val expectedContent = """
+            --target-executable
+            ${tool.path}
+            --target-working-directory
+            ${workingDirectory.path}
+            --snapshot-output
+            ${File(tempDir, "snapshot.dcvr").path}
+            --exclude-assemblies
+            fb
+            --exclude-attributes
+            afa,afb
+            --
+            arg1
+        """.trimIndent()
+
+        _ctx.checking(object : Expectations() {
+            init {
+                oneOf<CoverageFilterProvider>(_coverageFilterProvider).filters
+                will(returnValue(sequenceOf(
+                    CoverageFilter(CoverageFilter.CoverageFilterType.Include, CoverageFilter.Any, "fa", CoverageFilter.Any, CoverageFilter.Any),
+                    CoverageFilter(CoverageFilter.CoverageFilterType.Exclude, CoverageFilter.Any, "fb", CoverageFilter.Any, CoverageFilter.Any)
+                )))
+
+                oneOf<CoverageFilterProvider>(_coverageFilterProvider).attributeFilters
+                will(returnValue(sequenceOf(
+                    CoverageFilter(CoverageFilter.CoverageFilterType.Exclude, CoverageFilter.Any, CoverageFilter.Any, "afa", CoverageFilter.Any),
+                    CoverageFilter(CoverageFilter.CoverageFilterType.Exclude, CoverageFilter.Any, CoverageFilter.Any, "afb", CoverageFilter.Any),
+                )))
+
+                // include filter "fa" will trigger a warning
+                // JMock matcher returns default (null) value for String, and Kotlin doesn't like that, so have a dummy elvis operator fallback here
+                allowing<LoggerService>(_loggerService).writeWarning(with(anything<String>()) ?: "Glitter in the sky, glitter in my eyes")
+            }
+        })
+
+        val instance = createInstance()
+        val dotCoverProject = DotCoverProject(
+            DotCoverCommandType.Cover,
+            CoverCommandData(
+                CommandLine(null, TargetType.Tool, tool, workingDirectory, listOf(CommandLineArgument("arg1")), emptyList()),
+                Path(File(tempDir, "config.dotCover").path),
+                Path(File(tempDir, "snapshot.dcvr").path)
+            )
+        )
+
+        // Act
+        instance.serialize(dotCoverProject, outputStream)
+        val actual = String(outputStream.toByteArray()).trim()
+        val expected = expectedContent.trim()
+
+        // Assert
+        _ctx.assertIsSatisfied()
+        Assert.assertEquals(actual, expected)
+    }
+
+    @Test
+    fun `should generate merge command content`() {
+        val outputStream = ByteArrayOutputStream()
+        val tempDir = File("temp")
+        val expectedContent = """
+          --snapshot-source
+          ${File(tempDir, "1.dcvr").absolutePath},${File(tempDir, "2.dcvr").absolutePath},${File(tempDir, "3.dcvr").absolutePath}
+          --snapshot-output
+          ${File(tempDir, "outputSnapshot_BuildStep1.dcvr").absolutePath}
+      """.trimIndent()
+
+        val instance = createInstance()
+        val dotCoverProject = DotCoverProject(
+            DotCoverCommandType.Merge,
+            mergeCommandData = DotCoverProject.MergeCommandData(
+                listOf(
+                    Path(File(tempDir, "1.dcvr").absolutePath),
+                    Path(File(tempDir, "2.dcvr").absolutePath),
+                    Path(File(tempDir, "3.dcvr").absolutePath)
+                ),
+                Path(File(tempDir, "outputSnapshot_BuildStep1.dcvr").absolutePath)
+            )
+        )
+
+        instance.serialize(dotCoverProject, outputStream)
+        val actual = String(outputStream.toByteArray()).trim()
+
+        Assert.assertEquals(actual, expectedContent)
+    }
+
+    @Test
+    fun `should generate report command content`() {
+        val outputStream = ByteArrayOutputStream()
+        val tempDir = File("temp")
+        val expectedContent = """
+            --snapshot-source
+            ${File(tempDir, "outputSnapshot_BuildStep1.dcvr").absolutePath}
+            --xml-report-output
+            ${File(tempDir, "CoverageReport_BuildStep1.xml").absolutePath}
+        """.trimIndent()
+
+        val instance = createInstance()
+        val dotCoverProject = DotCoverProject(
+            DotCoverCommandType.Report,
+            reportCommandData = DotCoverProject.ReportCommandData(
+                Path(File(tempDir, "outputSnapshot_BuildStep1.dcvr").absolutePath),
+                Path(File(tempDir, "CoverageReport_BuildStep1.xml").absolutePath)
+            )
+        )
+
+        instance.serialize(dotCoverProject, outputStream)
+        val actual = String(outputStream.toByteArray()).trim()
+
+        Assert.assertEquals(actual, expectedContent)
+    }
+
+    @Test
+    fun `should generate cover command content when no filters`() {
+        val outputStream = ByteArrayOutputStream()
+        val tempDir = File("temp")
+        val workingDirectory = Path("workDir")
+        val tool = Path(File("wd", "tool").path)
+        val expectedContent = """
+            --target-executable
+            ${tool.path}
+            --target-working-directory
+            ${workingDirectory.path}
+            --snapshot-output
+            ${File(tempDir, "snapshot.dcvr").path}
+        """.trimIndent()
+
+        _ctx.checking(object : Expectations() {
+            init {
+                oneOf<CoverageFilterProvider>(_coverageFilterProvider).filters
+                will(returnValue(emptySequence<CoverageFilter>()))
+
+                oneOf<CoverageFilterProvider>(_coverageFilterProvider).attributeFilters
+                will(returnValue(emptySequence<CoverageFilter>()))
+            }
+        })
+
+        val instance = createInstance()
+        val dotCoverProject = DotCoverProject(
+            DotCoverCommandType.Cover,
+            CoverCommandData(
+                CommandLine(null, TargetType.Tool, tool, workingDirectory, emptyList(), emptyList()),
+                Path(File(tempDir, "config.dotCover").path),
+                Path(File(tempDir, "snapshot.dcvr").path)
+            )
+        )
+
+        instance.serialize(dotCoverProject, outputStream)
+        val actual = String(outputStream.toByteArray()).trim()
+
+        _ctx.assertIsSatisfied()
+        Assert.assertEquals(actual, expectedContent.trim())
+    }
+
+    private fun createInstance(): Serializer<DotCoverProject> {
+        return DotCoverResponseFileSerializerImpl(
+            _argumentsService,
+            _coverageFilterProvider,
+            _loggerService
+        )
+    }
+}

--- a/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/dotcover/DotCoverRunConfigFileSerializerTest.kt
+++ b/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/dotcover/DotCoverRunConfigFileSerializerTest.kt
@@ -9,7 +9,7 @@ import jetbrains.buildServer.dotcover.CoverageFilter
 import jetbrains.buildServer.dotcover.CoverageFilterProvider
 import jetbrains.buildServer.dotcover.DotCoverProject
 import jetbrains.buildServer.dotcover.DotCoverProject.*
-import jetbrains.buildServer.dotcover.DotCoverProjectSerializerImpl
+import jetbrains.buildServer.dotcover.DotCoverRunConfigFileSerializerImpl
 import jetbrains.buildServer.dotcover.command.DotCoverCommandType
 import jetbrains.buildServer.dotnet.test.agent.ArgumentsServiceStub
 import org.jmock.Expectations
@@ -24,7 +24,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.OutputStream
 
-class DotCoverProjectSerializerTest {
+class DotCoverRunConfigFileSerializerTest {
     private val _realXmlDocumentService: XmlDocumentService = XmlDocumentServiceImpl()
     private val _argumentsService: ArgumentsService = ArgumentsServiceStub()
     private lateinit var _ctx: Mockery
@@ -96,7 +96,6 @@ class DotCoverProjectSerializerTest {
                         CoverageFilter(CoverageFilter.CoverageFilterType.Exclude, CoverageFilter.Any, CoverageFilter.Any, "bbb", CoverageFilter.Any),
                         CoverageFilter(CoverageFilter.CoverageFilterType.Include, CoverageFilter.Any, CoverageFilter.Any, "ccc", CoverageFilter.Any)
                 )))
-
 
                 oneOf<XmlDocumentService>(_xmlDocumentService).serialize(document, outputStream)
                 will(object : CustomAction("doc") {
@@ -287,10 +286,11 @@ class DotCoverProjectSerializerTest {
     }
 
     private fun createInstance(): Serializer<DotCoverProject> {
-        return DotCoverProjectSerializerImpl(
+        return DotCoverRunConfigFileSerializerImpl(
                 _xmlDocumentService,
                 _argumentsService,
-                _coverageFilterProvider)
+                _coverageFilterProvider
+        )
     }
 
     private fun String.trimXml(): String {

--- a/plugin-dotnet-common/src/main/kotlin/jetbrains/buildServer/DotnetCoroutineDispatcher.kt
+++ b/plugin-dotnet-common/src/main/kotlin/jetbrains/buildServer/DotnetCoroutineDispatcher.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer
 
 import jetbrains.buildServer.util.executors.ExecutorsFactory

--- a/plugin-dotnet-common/src/main/kotlin/jetbrains/buildServer/Serializer.kt
+++ b/plugin-dotnet-common/src/main/kotlin/jetbrains/buildServer/Serializer.kt
@@ -1,5 +1,3 @@
-
-
 package jetbrains.buildServer
 
 import java.io.OutputStream

--- a/plugin-dotnet-server/src/main/kotlin/jetbrains/buildServer/dotCover/DotCoverPackageFilter.kt
+++ b/plugin-dotnet-server/src/main/kotlin/jetbrains/buildServer/dotCover/DotCoverPackageFilter.kt
@@ -12,16 +12,12 @@ class DotCoverPackageFilter : Filter<NuGetPackage> {
 
         val isCrossPlatformPackage: Boolean = DOTCOVER_DEPRECATED_PACKAGE_ID.equals(data.packageId, ignoreCase = true)
         val isValidCrossPlatformPackage = isCrossPlatformPackage && version.compareTo(OUR_VALID_CROSS_PLATFORM) >= 0
-        val isSupported = version.compareTo(FIRST_NOT_SUPPORTED_VERSION) < 0
 
-        return isSupported && (isValidCrossPlatformPackage || !isCrossPlatformPackage)
+        return isValidCrossPlatformPackage || !isCrossPlatformPackage
     }
 
     companion object {
         private val OUR_VALID_CROSS_PLATFORM = SemanticVersion.valueOf("2019.2.3")
-
-        // TODO: https://youtrack.jetbrains.com/issue/TW-95680
-        private val FIRST_NOT_SUPPORTED_VERSION = SemanticVersion.valueOf("2025.2.1")
     }
 }
 


### PR DESCRIPTION
Please note that there's a bug in DotCover [DCVR-13403](https://youtrack.jetbrains.com/issue/DCVR-13403) that might block e2e testing of the changes in this PR.