### PR TITLE
[TW-90683] Obfuscate the used key from the build log 

### DIFF
--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/CommandLineArgument.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/CommandLineArgument.kt
@@ -5,4 +5,5 @@ package jetbrains.buildServer.agent
 data class CommandLineArgument(
     val value: String,
     val argumentType: CommandLineArgumentType = CommandLineArgumentType.Secondary,
+    val isSensitive: Boolean = false,
 )

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/CommandLinePresentationServiceImpl.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/agent/CommandLinePresentationServiceImpl.kt
@@ -27,7 +27,7 @@ class CommandLinePresentationServiceImpl(
     override fun buildArgsPresentation(arguments: List<CommandLineArgument>): List<StdOutText> =
             arguments.map {
                 StdOutText(
-                        " ${_argumentsService.normalize(it.value)}",
+                        " ${if (it.isSensitive) SECRET_ARGUMENT_MASK else _argumentsService.normalize(it.value)}",
                         when (it.argumentType) {
                             CommandLineArgumentType.Mandatory -> Color.Default
                             CommandLineArgumentType.Target -> Color.Default
@@ -42,5 +42,10 @@ class CommandLinePresentationServiceImpl(
         _environment.os == _virtualContext.targetOSType -> File.separatorChar
         _virtualContext.targetOSType == OSType.WINDOWS -> '\\'
         else -> '/'
+    }
+
+    companion object {
+        // Placeholder shown in the build log instead of a sensitive argument value.
+        internal const val SECRET_ARGUMENT_MASK = "*******"
     }
 }

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotnet/commands/NugetDeleteCommand.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotnet/commands/NugetDeleteCommand.kt
@@ -36,7 +36,7 @@ class NugetDeleteCommand(
         parameters(DotnetConstants.PARAM_NUGET_API_KEY)?.trim()?.let {
             if (it.isNotBlank()) {
                 yield(CommandLineArgument("--api-key"))
-                yield(CommandLineArgument(it))
+                yield(CommandLineArgument(it, isSensitive = true))
             }
         }
 

--- a/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotnet/commands/NugetPushCommand.kt
+++ b/plugin-dotnet-agent/src/main/kotlin/jetbrains/buildServer/dotnet/commands/NugetPushCommand.kt
@@ -33,7 +33,7 @@ class NugetPushCommand(
         parameters(DotnetConstants.PARAM_NUGET_API_KEY)?.trim()?.let {
             if (it.isNotBlank()) {
                 yield(CommandLineArgument("--api-key"))
-                yield(CommandLineArgument(it))
+                yield(CommandLineArgument(it, isSensitive = true))
             }
         }
 

--- a/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/agent/runner/CommandLinePresentationServiceTest.kt
+++ b/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/agent/runner/CommandLinePresentationServiceTest.kt
@@ -55,7 +55,9 @@ class CommandLinePresentationServiceTest {
                 arrayOf(listOf(CommandLineArgument("Arg1", CommandLineArgumentType.Secondary)), listOf(StdOutText(" \"Arg1\""))),
                 arrayOf(listOf(CommandLineArgument("Arg1", CommandLineArgumentType.Custom)), listOf(StdOutText(" \"Arg1\""))),
                 arrayOf(listOf(CommandLineArgument("Arg1", CommandLineArgumentType.Infrastructural)), listOf(StdOutText(" \"Arg1\""))),
-                arrayOf(listOf(CommandLineArgument("Arg1", CommandLineArgumentType.Mandatory), CommandLineArgument("Arg2", CommandLineArgumentType.Custom)), listOf(StdOutText(" \"Arg1\""), StdOutText(" \"Arg2\""))))
+                arrayOf(listOf(CommandLineArgument("Arg1", CommandLineArgumentType.Mandatory), CommandLineArgument("Arg2", CommandLineArgumentType.Custom)), listOf(StdOutText(" \"Arg1\""), StdOutText(" \"Arg2\""))),
+                arrayOf(listOf(CommandLineArgument("secretApiKey", CommandLineArgumentType.Secondary, isSensitive = true)), listOf(StdOutText(" ${CommandLinePresentationServiceImpl.SECRET_ARGUMENT_MASK}"))),
+                arrayOf(listOf(CommandLineArgument("--api-key"), CommandLineArgument("secretApiKey", CommandLineArgumentType.Secondary, isSensitive = true)), listOf(StdOutText(" \"--api-key\""), StdOutText(" ${CommandLinePresentationServiceImpl.SECRET_ARGUMENT_MASK}"))))
     }
 
     @Test(dataProvider = "testArgsPresentation")

--- a/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/dotnet/commands/NugetDeleteCommandTest.kt
+++ b/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/dotnet/commands/NugetDeleteCommandTest.kt
@@ -60,6 +60,27 @@ class NugetDeleteCommandTest {
     }
 
     @Test
+    fun shouldMarkNugetApiKeyValueAsSensitive() {
+        // Given
+        val command = createCommand(
+            parameters = mapOf(
+                DotnetConstants.PARAM_NUGET_PACKAGE_ID to "id version",
+                DotnetConstants.PARAM_NUGET_API_KEY to "secret",
+                DotnetConstants.PARAM_NUGET_PACKAGE_SOURCE to "http://jb.com")
+        )
+
+        // When
+        val arguments = command.getArguments(DotnetCommandContext(ToolPath(Path("wd")), command)).toList()
+
+        // Then
+        val apiKeyFlagIndex = arguments.indexOfFirst { it.value == "--api-key" }
+        Assert.assertTrue(apiKeyFlagIndex >= 0, "The --api-key argument is expected")
+        val apiKeyValue = arguments[apiKeyFlagIndex + 1]
+        Assert.assertEquals(apiKeyValue.value, "secret")
+        Assert.assertTrue(apiKeyValue.isSensitive, "The NuGet API key value must be marked as sensitive")
+    }
+
+    @Test
     fun shouldProvideCommandType() {
         // Given
         val command = createCommand()

--- a/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/dotnet/commands/NugetPushCommandTest.kt
+++ b/plugin-dotnet-agent/src/test/kotlin/jetbrains/buildServer/dotnet/test/dotnet/commands/NugetPushCommandTest.kt
@@ -78,6 +78,33 @@ class NugetPushCommandTest {
         Assert.assertEquals(actualArguments, expectedArguments)
     }
 
+    @Test
+    fun shouldMarkNugetApiKeyValueAsSensitive() {
+        // Given
+        val command = createCommand(
+            parameters = mapOf(
+                DotnetConstants.PARAM_PATHS to "package.nupkg",
+                DotnetConstants.PARAM_NUGET_API_KEY to "secret",
+                DotnetConstants.PARAM_NUGET_PACKAGE_SOURCE to "http://jb.com"),
+            targets = sequenceOf("my.csproj")
+        )
+        val context = DotnetCommandContext(
+            workingDirectory = ToolPath(Path("wd")),
+            command = command,
+            toolVersion = Version.Empty
+        )
+
+        // When
+        val arguments = command.getArguments(context).toList()
+
+        // Then
+        val apiKeyFlagIndex = arguments.indexOfFirst { it.value == "--api-key" }
+        Assert.assertTrue(apiKeyFlagIndex >= 0, "The --api-key argument is expected")
+        val apiKeyValue = arguments[apiKeyFlagIndex + 1]
+        Assert.assertEquals(apiKeyValue.value, "secret")
+        Assert.assertTrue(apiKeyValue.isSensitive, "The NuGet API key value must be marked as sensitive")
+    }
+
     @DataProvider
     fun projectsArgumentsData(): Array<Array<Any>> {
         return arrayOf(


### PR DESCRIPTION
This pull request is dedicated to preventing the publication of the key used in the build log as plain text.